### PR TITLE
Correct links to default messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Perhaps you want people to be able to add labels to their own newly created issu
 
 ### Configuring Customized Responses
 
-You can use the [default responses](lib/defaults.js), but if you'd like to specify your own, create a file inside a `.github` folder, titled `teacherbot.yml` and include the following text:
+You can use the [default responses](https://github.com/teacher-bot/teacherbot/blob/master/index.js), but if you'd like to specify your own, create a file inside a `.github` folder, titled `teacherbot.yml` and include the following text:
 
 ```yml
 addCollaborators:


### PR DESCRIPTION
@hectorsector I noticed this link was broken while I was trying to update the on-demand repos. Do you agree this is the best place to point them?